### PR TITLE
Add toolz dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ black
 pytest
 torch
 torchvision
+toolz


### PR DESCRIPTION
Hello,

It looks like a dependency, `toolz`, has been accidentally omitted in `requirements.txt`. This library is used in `flyvision/network.py`, `flyvision/connectome.py`, and `flyvision/plots/network.py`. This PR aims to remedy this issue.